### PR TITLE
Resolves: BPX updated incompatible #118 

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
     runs-on: ${{ matrix.os }}
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
--
+- support for python < 3.10 (in line with BPX, etc.)
 
 
 ## [1.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
--
+- fixed tests/test data to work with updated BPX
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "python-socketio~=5.14.2",
   "websocket-client~=1.9.0",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   {name = "DandeLiion Team", email = "team@dandeliion.com"},
 ]

--- a/tests/python/dandeliion/client/data/input_bpx.json
+++ b/tests/python/dandeliion/client/data/input_bpx.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 1.1,
+            "BPX": "1.1",
             "Title": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell",
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"

--- a/tests/python/dandeliion/client/data/input_bpx.json
+++ b/tests/python/dandeliion/client/data/input_bpx.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
 	    "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8
+	          "Thermal conductivity [W.m-1.K-1]": 8.
             }
       }
 }

--- a/tests/python/dandeliion/client/data/input_bpx.json
+++ b/tests/python/dandeliion/client/data/input_bpx.json
@@ -1,20 +1,30 @@
 {
       "Header": {
-            "BPX": 0.3,
+            "BPX": 1.1,
             "Title": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell",
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"
       },
+      "State": {
+	        "Initial conditions": {
+	            "Initial electrolyte concentration [mol.m-3]": 1000,
+		    "Initial temperature [K]": 298.15,
+		    "Initial state-of-charge": 0.5,
+		    "Initial hysteresis state: Positive electrode": 1.0,
+		    "Initial hysteresis state: Negative electrode": 1.0
+		},
+		"Thermal environment": {
+		    "Ambient temperature [K]": 298.15,
+		    "Heat transfer coefficient [W.m-2.K-1]": 0.0
+                }
+      },
       "Parameterisation": {
             "Cell": {
-                  "Ambient temperature [K]": 298.15,
-                  "Initial temperature [K]": 298.15,
                   "Reference temperature [K]": 298.15,
                   "Lower voltage cut-off [V]": 2.5,
                   "Upper voltage cut-off [V]": 4.2,
                   "Nominal cell capacity [A.h]": 5,
                   "Specific heat capacity [J.K-1.kg-1]": 761,
-                  "Thermal conductivity [W.m-1.K-1]": 8,
                   "Density [kg.m-3]": 3151,
                   "Electrode area [m2]": 0.10752,
                   "Number of electrode pairs connected in parallel to make a cell": 1,
@@ -22,7 +32,6 @@
                   "Volume [m3]": 2.42e-05
             },
             "Electrolyte": {
-                  "Initial concentration [mol.m-3]": 1000,
                   "Cation transference number": 0.2594,
                   "Conductivity [S.m-1]": "0.1297 * (x / 1000) ** 3 - 2.51 * (x / 1000) ** 1.5 + 3.329 * (x / 1000)",
                   "Diffusivity [m2.s-1]": "8.794e-11 * (x / 1000) ** 2 - 3.972e-10 * (x / 1000) + 4.862e-10",
@@ -67,6 +76,9 @@
                   "Thickness [m]": 1.2e-05,
                   "Porosity": 0.47,
                   "Transport efficiency": 0.3222
+            },
+	    "User-defined": {
+	          "Thermal conductivity [W.m-1.K-1]": 8
             }
       }
 }

--- a/tests/python/dandeliion/client/data/input_bpx.json
+++ b/tests/python/dandeliion/client/data/input_bpx.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
 	    "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8.
+	          "Thermal conductivity [W.m-1.K-1]": 8.0
             }
       }
 }

--- a/tests/python/dandeliion/client/data/input_experiment.json
+++ b/tests/python/dandeliion/client/data/input_experiment.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
             "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8,
+	          "Thermal conductivity [W.m-1.K-1]": 8.,
                   "DandeLiion: Lumped": 0.0,
                   "DandeLiion: Experiment": {
                         "Instructions": ["Discharge at 1C until 3.8 V",

--- a/tests/python/dandeliion/client/data/input_experiment.json
+++ b/tests/python/dandeliion/client/data/input_experiment.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 1.1,
+            "BPX": "1.1",
             "Title": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell",
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"

--- a/tests/python/dandeliion/client/data/input_experiment.json
+++ b/tests/python/dandeliion/client/data/input_experiment.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.3,
+            "BPX": 1.1,
             "Title": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell",
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"

--- a/tests/python/dandeliion/client/data/input_experiment.json
+++ b/tests/python/dandeliion/client/data/input_experiment.json
@@ -5,16 +5,26 @@
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"
       },
+      "State": {
+	        "Initial conditions": {
+	            "Initial electrolyte concentration [mol.m-3]": 1000,
+		    "Initial temperature [K]": 298.15
+		},
+		"Thermal environment": {
+		    "Ambient temperature [K]": 298.15,
+		    "Heat transfer coefficient [W.m-2.K-1]": 0.0,
+		    "Initial state-of-charge": 1.0,
+		    "Initial hysteresis state: Positive electrode": 1.0,
+		    "Initial hysteresis state: Negative electrode": 1.0
+                }
+      },
       "Parameterisation": {
             "Cell": {
-                  "Ambient temperature [K]": 298.15,
-                  "Initial temperature [K]": 298.15,
                   "Reference temperature [K]": 298.15,
                   "Lower voltage cut-off [V]": 2.5,
                   "Upper voltage cut-off [V]": 4.2,
                   "Nominal cell capacity [A.h]": 5,
                   "Specific heat capacity [J.K-1.kg-1]": 761,
-                  "Thermal conductivity [W.m-1.K-1]": 8,
                   "Density [kg.m-3]": 3151,
                   "Electrode area [m2]": 0.10752,
                   "Number of electrode pairs connected in parallel to make a cell": 1,
@@ -22,7 +32,6 @@
                   "Volume [m3]": 2.42e-05
             },
             "Electrolyte": {
-                  "Initial concentration [mol.m-3]": 1000,
                   "Cation transference number": 0.2594,
                   "Conductivity [S.m-1]": "0.1297 * (x / 1000) ** 3 - 2.51 * (x / 1000) ** 1.5 + 3.329 * (x / 1000)",
                   "Diffusivity [m2.s-1]": "8.794e-11 * (x / 1000) ** 2 - 3.972e-10 * (x / 1000) + 4.862e-10",
@@ -69,9 +78,8 @@
                   "Transport efficiency": 0.3222
             },
             "User-defined": {
+	          "Thermal conductivity [W.m-1.K-1]": 8,
                   "DandeLiion: Lumped": 0.0,
-                  "DandeLiion: Heat transfer coefficient [W.m-2.K-1]": 0.0,
-                  "DandeLiion: Initial SOC": 1.0,
                   "DandeLiion: Experiment": {
                         "Instructions": ["Discharge at 1C until 3.8 V",
                                          "Hold at 3.8 V for 10 minutes",

--- a/tests/python/dandeliion/client/data/input_experiment.json
+++ b/tests/python/dandeliion/client/data/input_experiment.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
             "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8.,
+	          "Thermal conductivity [W.m-1.K-1]": 8.0,
                   "DandeLiion: Lumped": 0.0,
                   "DandeLiion: Experiment": {
                         "Instructions": ["Discharge at 1C until 3.8 V",

--- a/tests/python/dandeliion/client/data/invalid_input_bpx.json
+++ b/tests/python/dandeliion/client/data/invalid_input_bpx.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
 	    "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8
+	          "Thermal conductivity [W.m-1.K-1]": 8.
             }
       }
 }

--- a/tests/python/dandeliion/client/data/invalid_input_bpx.json
+++ b/tests/python/dandeliion/client/data/invalid_input_bpx.json
@@ -78,7 +78,7 @@
                   "Transport efficiency": 0.3222
             },
 	    "User-defined": {
-	          "Thermal conductivity [W.m-1.K-1]": 8.
+	          "Thermal conductivity [W.m-1.K-1]": 8.0
             }
       }
 }

--- a/tests/python/dandeliion/client/data/invalid_input_bpx.json
+++ b/tests/python/dandeliion/client/data/invalid_input_bpx.json
@@ -1,20 +1,30 @@
 {
       "Header": {
-            "BPX": 0.3,
+            "BPX": "1.1",
             "Title": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell",
             "Description": "About:Energy Gen1 Demo 21700 NMC811|graphite 5 Ah cell physics-based parameterisation. This is a fictitious cell used for technology demonstration. Some data are taken from literature: Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023); Chen et al. 2020 (doi:10.1149/1945-7111/ab9050); O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700).",
             "Model": "DFN"
       },
+      "State": {
+	        "Initial conditions": {
+	            "Initial electrolyte concentration [mol.m-3]": 1000,
+		    "Initial temperature [K]": 298.15,
+		    "Initial state-of-charge": 0.5,
+		    "Initial hysteresis state: Positive electrode": 1.0,
+		    "Initial hysteresis state: Negative electrode": 1.0
+		},
+		"Thermal environment": {
+		    "Ambient temperature [K]": 298.15,
+		    "Heat transfer coefficient [W.m-2.K-1]": 0.0
+                }
+      },
       "Parameterisation": {
             "Cell": {
-                  "Ambient temperature [K]": 298.15,
-                  "Initial temperature [K]": 298.15,
                   "Reference temperature [K]": 298.15,
                   "Lower voltage cut-off [V]": 2.5,
                   "Upper voltage cut-off [V]": 4.2,
                   "Nominal cell capacity [A.h]": 5,
                   "Specific heat capacity [J.K-1.kg-1]": 761,
-                  "Thermal conductivity [W.m-1.K-1]": 8,
                   "Density [kg.m-3]": 3151,
                   "Electrode area [m2]": 0.10752,
                   "Number of electrode pairs connected in parallel to make a cell": 1,
@@ -22,7 +32,6 @@
                   "Volume [m3]": 2.42e-05
             },
             "Electrolyte": {
-                  "Initial concentration [mol.m-3]": 1000,
                   "Cation transference number": 0.2594,
                   "Conductivity [S.m-1]": "0.1297 * (x / 1000) ** 3 - 2.51 * (x / 1000) ** 1.5 + 3.329 * (x / 1000)",
                   "Diffusivity [m2.s-1]": "8.794e-11 * (x / 1000) ** 2 - 3.972e-10 * (x / 1000) + 4.862e-10",
@@ -67,6 +76,9 @@
                   "Thickness [m]": 1.2e-05,
                   "Porosity": 0.47,
                   "Transport efficiency": 0.3222
+            },
+	    "User-defined": {
+	          "Thermal conductivity [W.m-1.K-1]": 8
             }
       }
 }

--- a/tests/python/dandeliion/client/solve_test.py
+++ b/tests/python/dandeliion/client/solve_test.py
@@ -34,6 +34,7 @@ from dandeliion.client import solve, _convert_experiment
 from dandeliion.client.experiment import Experiment as DandeLiionExperiment
 
 # third-party modules
+from copy import deepcopy
 import pybamm
 from bpx import parse_bpx_file
 import numpy as np
@@ -62,7 +63,8 @@ def invalid_input_bpx():
     filename = Path(__file__).parent / 'data' / 'invalid_input_bpx.json'
     with open(filename, 'r') as f:
         params = json.load(f)
-    params['Parameterisation']["User-defined"] = {}
+    if "User-defined" not in params['Parameterisation']:
+        params['Parameterisation']["User-defined"] = {}
     return filename, params
 
 
@@ -157,9 +159,11 @@ def test_solve_with_bpx_dict(mock_convert, input_bpx):
 
     experiment = mock.Mock(),
 
+    bpx_dict = deepcopy(input_bpx[1])
+
     solution = solve(
         simulator=mock_simulator,
-        params=input_bpx[1],
+        params=bpx_dict,
         experiment=experiment
     )
 

--- a/tests/python/dandeliion/client/solve_test.py
+++ b/tests/python/dandeliion/client/solve_test.py
@@ -49,7 +49,8 @@ def input_bpx():
     filename = Path(__file__).parent / 'data' / 'input_bpx.json'
     with open(filename, 'r') as f:
         params = json.load(f)
-    params['Parameterisation']["User-defined"] = {}
+    if "User-defined" not in params['Parameterisation']:
+        params['Parameterisation']["User-defined"] = {}
     return filename, params
 
 


### PR DESCRIPTION
Fixed tests / test data:
   - moved former Dandeliion parameters into new `State` subsection where applicable
   - moved former Cell / Electrolyte parameters into new `State` subsection where applicable
   - moved no longer supported `Thermal conductivity [W.m-1.K-1]` to `User-defined`

Closes #118 