### PR TITLE
Expose structured token validation details in the Python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--
+- `TokenValidation` metadata on successful simulation submissions
+- `DandeliionTokenValidationError` with structured rejected-token details
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
--
+- Constrained BPX to the supported 0.5 release line
 
 ### Changed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025, DandeLiion Team
+Copyright (c) 2025-2026, DandeLiion Technologies Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,44 @@ api_key = "API_TOKEN"
 simulator = dandeliion.Simulator(api_url, api_key)
 ```
 
+## Token validation details
+
+New simulation submissions expose the token validation performed by the
+DandeLiion API. After a successful submission, the returned solution provides
+the token status, UTC expiry, and post-submission shared usage balance:
+
+```python
+solution = dandeliion.solve(
+    simulator=simulator,
+    params=params,
+    experiment=experiment,
+    is_blocking=False,
+)
+
+validation = solution.token_validation
+if validation is not None:  # None when using an older DandeLiion API
+    print(validation.status)
+    print(validation.expires_at)
+    print(validation.uses_remaining)
+```
+
+If a token is invalid, expired, deactivated, exhausted, or belongs to an
+inactive user, submission raises
+`dandeliion.DandeliionTokenValidationError`. Its `validation` property contains
+the same structured details:
+
+```python
+try:
+    solution = simulator.submit(parameters, is_blocking=False)
+except dandeliion.DandeliionTokenValidationError as exc:
+    print(exc.validation.status)
+    print(exc.validation.expires_at)
+    print(exc.validation.uses_remaining)
+```
+
+Validator-service outages remain regular `DandeliionAPIException` failures and
+do not include token metadata.
+
 ## Simulation parameters and models
 
 Define the battery cell parameters by providing the BPX file name (as a string or `pathlib.Path`), a valid BPX as a `dict`, or `BPX` object itself. For example:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,6 @@ We encourage responsible disclosure of security vulnerabilities. If you find som
 
 In order for the vulnerability reports to reach maintainers as soon as possible, the preferred way is to use the "Report a vulnerability" button under the "Security" tab of the associated GitHub project. This creates a private communication channel between the reporter and the maintainers.
 
-If you are absolutely unable to or have strong reasons not to use GitHub's vulnerability reporting workflow, please reach out to the Dandeliion team at [team@dandeliion.com](mailto:team@dandeliion.com).
+If you are absolutely unable to or have strong reasons not to use GitHub's vulnerability reporting workflow, please contact DandeLiion Technologies Limited at [team@dandeliion.com](mailto:team@dandeliion.com).
 
 [gh-organization]: https://github.com/dandeliion-team

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'DandeLiion Client'
-copyright = '2024-2025, DandeLiion Team'
-author = 'DandeLiion Team'
+copyright = '2024-2026, DandeLiion Technologies Limited'
+author = 'DandeLiion Technologies Limited'
 release = '1.3'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,5 +118,7 @@ where the following classes & methods have been used:
 
    dandeliion.client.Simulator
    dandeliion.client.Solution
+   dandeliion.client.TokenValidation
+   dandeliion.client.DandeliionTokenValidationError
    dandeliion.client.solve
    dandeliion.client.experiment.Experiment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
 ]
 dependencies = [
-  "bpx",
+  "bpx~=0.5.0",
   "requests~=2.32.3",
   "python-socketio~=5.14.2",
   "websocket-client~=1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ dependencies = [
 ]
 requires-python = ">=3.9"
 authors = [
-  {name = "DandeLiion Team", email = "team@dandeliion.com"},
+  {name = "DandeLiion Technologies Limited", email = "team@dandeliion.com"},
 ]
 maintainers = [
-  {name = "DandeLiion Team", email = "team@dandeliion.com"},
+  {name = "DandeLiion Technologies Limited", email = "team@dandeliion.com"},
 ]
 
 [project.urls]

--- a/src/python/dandeliion/client/__init__.py
+++ b/src/python/dandeliion/client/__init__.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 # custom modules
 from .simulator import Simulator
 from .solution import Solution
+from .exceptions import DandeliionAPIException, DandeliionTokenValidationError
+from .token import TokenStatus, TokenValidation
 
 # third-party modules
 try:
@@ -18,6 +20,16 @@ except ModuleNotFoundError:
     __has_pybamm__ = False
 from bpx import parse_bpx_obj, parse_bpx_file, BPX
 import numpy as np
+
+__all__ = [
+    "DandeliionAPIException",
+    "DandeliionTokenValidationError",
+    "Simulator",
+    "Solution",
+    "TokenStatus",
+    "TokenValidation",
+    "solve",
+]
 
 __version__ = importlib.metadata.version('dandeliion-client')
 

--- a/src/python/dandeliion/client/exceptions.py
+++ b/src/python/dandeliion/client/exceptions.py
@@ -8,3 +8,11 @@ class DandeliionAPIException(Exception):
     raw error message from the API.
     """
     pass
+
+
+class DandeliionTokenValidationError(DandeliionAPIException):
+    """Raised when the API rejects a simulation submission's token."""
+
+    def __init__(self, message, validation):
+        super().__init__(message)
+        self.validation = validation

--- a/src/python/dandeliion/client/simulator.py
+++ b/src/python/dandeliion/client/simulator.py
@@ -34,8 +34,9 @@ from typing import Optional, Union
 # custom modules
 from .tools.misc import update_dict
 from .websocket import SimulatorWebSocketClient
-from .exceptions import DandeliionAPIException
+from .exceptions import DandeliionAPIException, DandeliionTokenValidationError
 from .solution import Solution
+from .token import TokenValidation
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,16 @@ def get_error_message(response):
         # If response is not JSON (or expected field missing), fall back to reason text
         error_message = response.reason
     return error_message
+
+
+def get_token_validation(response):
+    """Extract typed token metadata when it is present and trustworthy."""
+    try:
+        payload = response.json()
+        token_payload = payload["Token"]
+        return TokenValidation.from_dict(token_payload)
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 @dataclass
@@ -83,9 +94,11 @@ class Simulator:
         headers = {'Authorization': f'Token {self.api_key}'}  # TODO adapt to server
         response = requests.post(url=self.api_url, json=parameters, headers=headers)
         if response.status_code >= 400:
-            raise DandeliionAPIException(
-                f"Your request has failed: {response.status_code} - {get_error_message(response)}"
-            )
+            message = f"Your request has failed: {response.status_code} - {get_error_message(response)}"
+            token_validation = get_token_validation(response)
+            if response.status_code == 403 and token_validation is not None and not token_validation.valid:
+                raise DandeliionTokenValidationError(message, token_validation)
+            raise DandeliionAPIException(message)
         response_json = response.json()
         data = update_dict(parameters, response_json, inline=False)
         if 'api_url' not in data['Run']:  # if not provided by server

--- a/src/python/dandeliion/client/simulator.py
+++ b/src/python/dandeliion/client/simulator.py
@@ -5,7 +5,7 @@ module containing Dandeliion Simulator class
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/src/python/dandeliion/client/solution.py
+++ b/src/python/dandeliion/client/solution.py
@@ -32,6 +32,7 @@ from collections.abc import Mapping
 
 # custom modules
 from .exceptions import DandeliionAPIException
+from .token import TokenValidation
 
 # third-party modules
 import numpy as np
@@ -186,6 +187,19 @@ class Solution(Mapping):
             str: contents of log file (runtime_log.txt)
         """
         return self._sim.get_log(self._data)
+
+    @property
+    def token_validation(self):
+        """Return token status, expiry, and post-submission remaining uses."""
+        payload = self._data.get("Token")
+        if payload is None:
+            return None
+        try:
+            return TokenValidation.from_dict(payload)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise DandeliionAPIException(
+                "The API returned invalid token validation metadata"
+            ) from exc
 
     def dump(self, filepath: Union[str, Path]):
         """

--- a/src/python/dandeliion/client/solution.py
+++ b/src/python/dandeliion/client/solution.py
@@ -5,7 +5,7 @@ Module containing class for handling access to solutions
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/src/python/dandeliion/client/token.py
+++ b/src/python/dandeliion/client/token.py
@@ -1,0 +1,81 @@
+"""Public token-validation metadata returned by the DandeLiion API."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Optional
+
+
+TokenStatus = Literal[
+    "valid",
+    "invalid",
+    "expired",
+    "deactivated",
+    "usage_exhausted",
+    "user_inactive",
+]
+
+SUPPORTED_TOKEN_STATUSES = frozenset(
+    {
+        "valid",
+        "invalid",
+        "expired",
+        "deactivated",
+        "usage_exhausted",
+        "user_inactive",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TokenValidation:
+    """A point-in-time token validation result from a simulation submission."""
+
+    valid: bool
+    status: TokenStatus
+    expires_at: Optional[datetime]
+    uses_remaining: Optional[int]
+    error: Optional[str]
+
+    @classmethod
+    def from_dict(cls, payload):
+        """Build typed validation metadata from an API response object."""
+        if not isinstance(payload, dict):
+            raise TypeError("Token validation metadata must be an object")
+
+        valid = payload["valid"]
+        status = payload["status"]
+        expires_at = payload["expires_at"]
+        uses_remaining = payload["uses_remaining"]
+        error = payload["error"]
+
+        if not isinstance(valid, bool):
+            raise TypeError("Token validation 'valid' must be a boolean")
+        if not isinstance(status, str) or status not in SUPPORTED_TOKEN_STATUSES:
+            raise ValueError("Token validation status is not supported")
+        if valid != (status == "valid"):
+            raise ValueError("Token validation status is inconsistent")
+
+        parsed_expiry = None
+        if expires_at is not None:
+            if not isinstance(expires_at, str):
+                raise TypeError("Token expiry must be an ISO 8601 string")
+            parsed_expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if parsed_expiry.tzinfo is None:
+                raise ValueError("Token expiry must include a timezone")
+
+        if uses_remaining is not None and (
+            not isinstance(uses_remaining, int)
+            or isinstance(uses_remaining, bool)
+            or uses_remaining < 0
+        ):
+            raise ValueError("Token uses remaining must be a non-negative integer")
+        if error is not None and not isinstance(error, str):
+            raise TypeError("Token validation error must be a string or None")
+
+        return cls(
+            valid=valid,
+            status=status,
+            expires_at=parsed_expiry,
+            uses_remaining=uses_remaining,
+            error=error,
+        )

--- a/src/python/dandeliion/client/websocket.py
+++ b/src/python/dandeliion/client/websocket.py
@@ -5,7 +5,7 @@ Module for websocket client used in simulator
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/python/dandeliion/client/mock_simulator.py
+++ b/tests/python/dandeliion/client/mock_simulator.py
@@ -5,7 +5,7 @@ module containing Dandeliion MockSimulator class
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/python/dandeliion/client/simulator_test.py
+++ b/tests/python/dandeliion/client/simulator_test.py
@@ -28,11 +28,13 @@ import logging
 import json
 import copy
 import pytest
+from datetime import datetime, timezone
 from unittest import mock
 from pathlib import Path
 
 # custom modules
 from dandeliion.client.simulator import Simulator, Solution, DandeliionAPIException
+from dandeliion.client.exceptions import DandeliionTokenValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +191,111 @@ def test_submit_server_error(mock_post, input_extended_bpx, error):
     simulator = Simulator(api_url=mock_url, api_key=mock_api_key)
     with pytest.raises(DandeliionAPIException, match=f"Your request has failed: {error_code} - {expected_message}"):
         simulator.submit(input_extended_bpx, is_blocking=False)
+
+
+@mock.patch('dandeliion.client.simulator.requests.post')
+def test_submit_exposes_token_validation(mock_post, input_extended_bpx):
+    token_payload = {
+        "valid": True,
+        "status": "valid",
+        "expires_at": "2026-12-31T23:59:59Z",
+        "uses_remaining": 49,
+        "error": None,
+    }
+    mock_post.return_value = MockResponse(
+        json_data={
+            "Run": {"ws_status_url": "wss://example/ws", "id": "run_1"},
+            "Token": token_payload,
+        },
+        status_code=200,
+    )
+
+    solution = Simulator(api_url="https://api.example/v1", api_key="token").submit(
+        input_extended_bpx,
+        is_blocking=False,
+    )
+
+    assert solution.token_validation.valid is True
+    assert solution.token_validation.status == "valid"
+    assert solution.token_validation.expires_at == datetime(
+        2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc
+    )
+    assert solution.token_validation.uses_remaining == 49
+    assert solution.token_validation.error is None
+
+
+@pytest.mark.parametrize(
+    ("status", "expires_at", "uses_remaining"),
+    [
+        ("invalid", None, None),
+        ("expired", "2026-01-01T00:00:00Z", 10),
+        ("deactivated", "2026-12-31T23:59:59Z", 10),
+        ("usage_exhausted", "2026-12-31T23:59:59Z", 0),
+        ("user_inactive", "2026-12-31T23:59:59Z", 10),
+    ],
+)
+@mock.patch('dandeliion.client.simulator.requests.post')
+def test_submit_raises_structured_token_error(
+    mock_post,
+    input_extended_bpx,
+    status,
+    expires_at,
+    uses_remaining,
+):
+    token_payload = {
+        "valid": False,
+        "status": status,
+        "expires_at": expires_at,
+        "uses_remaining": uses_remaining,
+        "error": status.replace("_", " "),
+    }
+    mock_post.return_value = MockResponse(
+        json_data={"error": token_payload["error"], "Token": token_payload},
+        status_code=403,
+        reason="Forbidden",
+    )
+
+    simulator = Simulator(api_url="https://api.example/v1", api_key="token")
+    with pytest.raises(DandeliionTokenValidationError) as raised:
+        simulator.submit(input_extended_bpx, is_blocking=False)
+
+    assert isinstance(raised.value, DandeliionAPIException)
+    assert raised.value.validation.status == status
+    assert raised.value.validation.uses_remaining == uses_remaining
+    if expires_at is None:
+        assert raised.value.validation.expires_at is None
+    else:
+        assert raised.value.validation.expires_at.tzinfo == timezone.utc
+
+
+@mock.patch('dandeliion.client.simulator.requests.post')
+def test_submit_validator_outage_remains_generic_api_error(mock_post, input_extended_bpx):
+    mock_post.return_value = MockResponse(
+        json_data={"error": "The token validator is unavailable"},
+        status_code=503,
+        reason="Service Unavailable",
+    )
+
+    simulator = Simulator(api_url="https://api.example/v1", api_key="token")
+    with pytest.raises(DandeliionAPIException) as raised:
+        simulator.submit(input_extended_bpx, is_blocking=False)
+
+    assert not isinstance(raised.value, DandeliionTokenValidationError)
+
+
+@mock.patch('dandeliion.client.simulator.requests.post')
+def test_submit_older_api_response_has_no_token_validation(mock_post, input_extended_bpx):
+    mock_post.return_value = MockResponse(
+        json_data={"Run": {"ws_status_url": "wss://example/ws", "id": "run_1"}},
+        status_code=200,
+    )
+
+    solution = Simulator(api_url="https://api.example/v1", api_key="token").submit(
+        input_extended_bpx,
+        is_blocking=False,
+    )
+
+    assert solution.token_validation is None
 
 
 @mock.patch('dandeliion.client.simulator.requests.get')

--- a/tests/python/dandeliion/client/simulator_test.py
+++ b/tests/python/dandeliion/client/simulator_test.py
@@ -5,7 +5,7 @@ Testing the routines for dandeliion.client.Simulator
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/python/dandeliion/client/solution_test.py
+++ b/tests/python/dandeliion/client/solution_test.py
@@ -5,7 +5,7 @@ Testing the routines for dandeliion.client.Simulator
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/python/dandeliion/client/solve_test.py
+++ b/tests/python/dandeliion/client/solve_test.py
@@ -5,7 +5,7 @@ Testing the solve routines in dandeliion.client
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -391,4 +391,3 @@ def test__convert_experiment_without_pybamm():
     assert converted_experiment['Period'] == "1 second"
     assert converted_experiment['Temperature'] is None
     assert converted_experiment['Termination'] is None
-

--- a/tests/python/dandeliion/client/tools/misc_test.py
+++ b/tests/python/dandeliion/client/tools/misc_test.py
@@ -5,7 +5,7 @@ Testing the routines for dandeliion.client.tools.misc
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/python/dandeliion/client/websocket_test.py
+++ b/tests/python/dandeliion/client/websocket_test.py
@@ -5,7 +5,7 @@ Testing the routines for dandeliion.client.websocket
 """
 
 #
-# Copyright (C) 2024-2025 Dandeliion Team
+# Copyright (C) 2024-2026 DandeLiion Technologies Limited
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
## Why

The DandeLiion API now returns structured information from the Token Portal after validating a simulation submission. Python users should be able to inspect the token status, expiry, and remaining shared uses without parsing error strings.

## What changed

- Added the immutable public `TokenValidation` model.
- Added the typed statuses `valid`, `invalid`, `expired`, `deactivated`, `usage_exhausted`, and `user_inactive`.
- Added `Solution.token_validation` for successful submissions.
- Added `DandeliionTokenValidationError`, derived from `DandeliionAPIException`, for rejected submissions.
- The exception’s `validation` property exposes the same structured token metadata.
- Preserved generic `DandeliionAPIException` behavior for validator outages and other non-token API failures.
- Preserved compatibility with older API deployments: `solution.token_validation` is `None` when the response has no `Token` section.
- Documented the new interface and updated the changelog.
- Constrained BPX to the documented supported `0.5.x` release line; newer BPX 1.x changes legacy conversion behavior and breaks the existing client tests.

## Example

```python
try:
    solution = dandeliion.solve(
        simulator=simulator,
        params=params,
        experiment=experiment,
        is_blocking=False,
    )
except dandeliion.DandeliionTokenValidationError as exc:
    print(exc.validation.status)
    print(exc.validation.expires_at)
    print(exc.validation.uses_remaining)
else:
    validation = solution.token_validation
    if validation is not None:
        print(validation.status)
        print(validation.expires_at)
        print(validation.uses_remaining)